### PR TITLE
Temporary disable autoload of plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
   "prefer-stable": true,
   "extra": {
     "installer-paths": {
-      "public_html/mu-plugins/{$name}/": ["type:wordpress-muplugin", "type:wordpress-plugin"],
+      "public_html/plugins/{$name}/": ["type:wordpress-muplugin", "type:wordpress-plugin"],
       "public_html/themes/{$name}/": ["type:wordpress-theme"]
     },
     "dropin-paths": {


### PR DESCRIPTION
Because :
* AutoLoader cannot deal with global variables used by wp-youtube-lyte
* wp-youtube-lyte has hardcoded paths to the plugins sub-directory